### PR TITLE
Exclude non-technical jobs in GitHub numbers

### DIFF
--- a/data.txt
+++ b/data.txt
@@ -342,8 +342,8 @@
 	last_updated: 2013-10-25
 [github]
 	company: GitHub
-	num_female_eng: 30
-	num_eng: 218
+	num_female_eng: 10
+	num_eng: 160
 	last_updated: 2013-10-26
 [bitly]
 	company: Bitly


### PR DESCRIPTION
The first pass for GitHub numbers included all employees. This PR changes them to reflect only employees whose primary job is technical.
