### PR TITLE
Add Yelp

### DIFF
--- a/data.txt
+++ b/data.txt
@@ -298,6 +298,12 @@
 	num_female_eng: 2
 	num_eng: 7
 	last_updated: 2013-10-24
+[yelp]
+	company: Yelp
+	team: Engineering
+	num_female_eng: 17
+	num_eng: 206
+	last_updated: 2014-01-13
 [squareroot]
 	company: square-root.com
 	num_female_eng: 2


### PR DESCRIPTION
Contributed by Eevee (Alex Munroe), @eevee.  I can email you from a Yelp address if necessary.

Source: I asked HR and they gave me a spreadsheet that I'm pretty sure just came from LDAP.

We have somewhat fuzzy roles, and after some internal discussion, I decided to eliminate upper management + part-timers and leave everyone else who's listed as being in the engineering department.  DBAs and ops still write tons of code without which the site wouldn't exist, and that makes it very hard to figure out where to draw the line, so I drew it nowhere.
