### PR TITLE
Updating data for Medium to include new hires and DevOps team

### DIFF
--- a/data.txt
+++ b/data.txt
@@ -57,9 +57,9 @@
 	last_updated: 2013-11-11
 [medium]
 	company: Medium
-	num_female_eng: 9
-	num_eng: 33
-	last_updated: 2015-01-06
+	num_female_eng: 10
+	num_eng: 36
+	last_updated: 2015-02-27
 [renttherunway]
 	company: Rent the Runway
 	num_female_eng: 7


### PR DESCRIPTION
Contributor: Dan Pupius, Head of Engineering, @dpup
Source: My magic spreadsheet of knowledge

This includes our latest hires and makes sure our dev ops team are accounted for (which should really be included when looking at these numbers). It doesn't include 2 IT, 2 QA, ad 1 admin.