### PR TITLE
Adding EnergySavvy

### DIFF
--- a/data.txt
+++ b/data.txt
@@ -752,6 +752,11 @@
 	num_female_eng: 11
 	num_eng: 61
 	last_updated: 2015-01-05
+[energysavvy]
+	company: EnergySavvy
+	num_female_eng: 7
+	num_eng: 35
+	last_updated: 2015-05-08
 [codeforamerica]
 	company: Code for America
 	num_female_eng: 2


### PR DESCRIPTION
Contributor: Bri Dotson, software developer at EnergySavvy, Ada Developers Academy Cohort[1],
    @bri616
Source: internal headcount, admin documents

EnergySavvy is 6 out of 29 if you count only developers, 7 out of 35 counting PMs (who also contribute code on a regular basis, which is why this is the chosen ratio), and 8 out of 36 if you count the the VP of Engineering.