### PR TITLE
Add numbers for The Slate Group (Slate/Panoply)

### DIFF
--- a/data.txt
+++ b/data.txt
@@ -1116,6 +1116,11 @@
 	num_female_eng: 13
 	num_eng: 71
 	last_updated: 2015-06-16
+[slate]
+	company: The Slate Group
+	num_female_eng: 4
+	num_eng: 12
+	last_updated: 2015-10-13
 [eventbrite]
 	company: Eventbrite
 	num_female_eng: 14


### PR DESCRIPTION
Adding The Slate Group which includes both Slate and Panoply.

Contributor: Sara Martinez, software engineer for Slate, @saramartinez
Source: Internal headcount

Slate is 3/8 and Panoply is 1/4, but all fall under The Slate Group umbrella. This does not include The Root, which is now part of Univision.