### PR TITLE
Specify team for The Slate Group

### DIFF
--- a/data.txt
+++ b/data.txt
@@ -1118,6 +1118,7 @@
 	last_updated: 2015-06-16
 [slate]
 	company: The Slate Group
+	team: Slate/Panoply Engineering
 	num_female_eng: 4
 	num_eng: 12
 	last_updated: 2015-10-13


### PR DESCRIPTION
When I looked at the spreadsheet to see the numbers I had added earlier this week, I realized I had overlooked the "team" field. I want to specify that this is the engineering team for Slate/Panoply, because there are additionally two male interactive editors who produce JavaScript-heavy features for editorial — they are not counted here.