### PR TITLE
Update The Slate Group to reflect new hire and separate Slate/Panoply

### DIFF
--- a/data.txt
+++ b/data.txt
@@ -1133,10 +1133,16 @@
 	last_updated: 2015-06-16
 [slate]
 	company: The Slate Group
-	team: Slate/Panoply Engineering
-	num_female_eng: 4
-	num_eng: 12
-	last_updated: 2015-10-13
+	team: Slate.com Engineering
+	num_female_eng: 3
+	num_eng: 9
+	last_updated: 2015-12-04
+[panoply]
+	company: The Slate Group
+	team: Panoply Engineering
+	num_female_eng: 1
+	num_eng: 4
+	last_updated: 2015-12-04
 [eventbrite]
 	company: Eventbrite
 	num_female_eng: 14


### PR DESCRIPTION
Updating The Slate Group.

Contributor: Sara J. Martinez, Software Engineer for Slate Custom / @saramartinez
Source: internal headcount

We had a new hire and now treat Slate developers and Panoply (panoply.fm) developers as separate teams, so I updated this to reflect that. The Slate Group is 4 out of 13 while Slate developers (including devops) are 3/9 and Panoply is 1/4. 