### PR TITLE
Account for 2 new hires on Panoply/Megaphone.fm team

### DIFF
--- a/data.txt
+++ b/data.txt
@@ -1151,13 +1151,13 @@
 	team: Slate.com Engineering
 	num_female_eng: 3
 	num_eng: 9
-	last_updated: 2015-12-04
+	last_updated: 2016-04-25
 [panoply]
 	company: The Slate Group
 	team: Panoply Engineering
 	num_female_eng: 1
-	num_eng: 4
-	last_updated: 2015-12-04
+	num_eng: 6
+	last_updated: 2016-04-25
 [eventbrite]
 	company: Eventbrite
 	num_female_eng: 14


### PR DESCRIPTION
Updating Panoply/Megaphone.fm of The Slate Group

Contributor: Sara J. Martinez, Software Engineer for Slate / @saramartinez
Source: internal headcount

2 new hires on Panoply, both male, bringing count to 1 female out of 6 on the Panoply/Megaphone team. Also updates date for Slate though the count has not changed.