### PR TITLE
Update Patreon data

### DIFF
--- a/data.txt
+++ b/data.txt
@@ -1057,9 +1057,9 @@
   last_updated: 2014-10-17
 [patreon]
   company: Patreon
-  num_female_eng: 1
-  num_eng: 7
-  last_updated: 2014-11-26
+  num_female_eng: 8
+  num_eng: 32
+  last_updated: 2017-07-10
 [tricae]
   company: Tricae
   num_female_eng: 1


### PR DESCRIPTION
Updating Patreon data

Contributor: Maura Church, Data Science Manager at Patreon
    @outoftheverse
Source: internal headcount

To be as inclusive as possible to people of all genders, the `num_female_eng` count includes all engineers who are not cisgender men.