### PR TITLE
Updating numbers for GreenSync

### DIFF
--- a/data.txt
+++ b/data.txt
@@ -1377,3 +1377,8 @@
   num_female_eng: 6
   num_eng: 24
   last_updated: 2017-07-10
+[greensync]
+  company: GreenSync
+  num_female_eng: 4
+  num_eng: 24
+  last_updated: 2017-08-07


### PR DESCRIPTION
Contributor: Tim Hordern, Team Lead, GreenSync
    @mence
Source: internal headcount

GreenSync is 4 out of 24 engineers.